### PR TITLE
Avoid error message if Docker is not started

### DIFF
--- a/common/templates/.bash_profile.j2
+++ b/common/templates/.bash_profile.j2
@@ -28,7 +28,8 @@ export M2_HOME=/usr/local/opt/maven/libexec
 export GRADLE_HOME=/usr/local/opt/gradle/libexec
 export GRADLE_OPTS=-Dfile.encoding=utf-8
 
-eval "$(docker-machine env)"
+docker-machine status | grep -q Running
+if [[ $? -eq 0 ]]; then eval "$(docker-machine env)"; fi
 export DOCKER_HOSTNAME=$(echo "$DOCKER_HOST" | sed -E 's|(.*//)?([^/:]*).*|\2|g')
 export DOCKER_IP=$(echo "$DOCKER_HOST" | sed -E 's|(.*//)?([^/:]*).*|\2|g')
 


### PR DESCRIPTION
Without this, the following error will be displayed on the terminal if the Docker machine is not started:

```
$ eval "$(docker-machine env)"
Error checking TLS connection: Host is not running
```