### PR TITLE
Add vault to common tools

### DIFF
--- a/common/tasks/main.yml
+++ b/common/tasks/main.yml
@@ -29,6 +29,7 @@
     - coreutils
     - bash
     - shunit2
+    - vault
 
 - name: Install common binary tools
   homebrew_cask: name={{item}}


### PR DESCRIPTION
This tool is necessary in the process of configuring the Kubernetes secrets on the Preprod environment.